### PR TITLE
DPT-498 address link with version type issues

### DIFF
--- a/src/Resource/Asset.php
+++ b/src/Resource/Asset.php
@@ -20,6 +20,7 @@ use Contentful\Management\Resource\Behavior\DeletableTrait;
 use Contentful\Management\Resource\Behavior\PublishableTrait;
 use Contentful\Management\Resource\Behavior\UpdatableTrait;
 use Contentful\Management\SystemProperties\Asset as SystemProperties;
+use Contentful\Management\LinkWithVersion;
 
 /**
  * Asset class.

--- a/src/Resource/BulkActionPublish.php
+++ b/src/Resource/BulkActionPublish.php
@@ -57,4 +57,12 @@ class BulkActionPublish extends BulkAction implements CreatableInterface
     {
         return [];
     }
+
+    /**
+     * @return LinkWithVersion[]
+     */
+    public function getItems(): array
+    {
+        return parent::getItems();
+    }
 }


### PR DESCRIPTION
There are a few issues with the namespaces assigned to some versions that are causing new tests written as part of the implementation for DPT-498 to fail. This addresses those small type / doc issues.